### PR TITLE
Add D-YAML to the Jenkins Autotester

### DIFF
--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -306,6 +306,7 @@ DFLAGS=-I%@P%/../imports -L-L%@P%/../libs -L--export-dynamic -L--export-dynamic 
         "rejectedsoftware/vibe.d",
         "repeatedly/mustache-d",
         "s-ludwig/taggedalgebraic",
+        "dlang-community/D-YAML",
     ]
 
     stage ('Test Projects') {


### PR DESCRIPTION
After D-YAML broke now twice this month due to regressions:
- https://github.com/dlang-community/D-YAML/issues/66
- https://github.com/dlang-community/D-YAML/issues/63

Imho it's time to test it on project tester: