### PR TITLE
Remove 'interactive remove test' from DUB

### DIFF
--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -170,6 +170,7 @@ def testDownstreamProject (name) {
                 case 'dlang/dub':
                     sh '''
                       rm test/issue884-init-defer-file-creation.sh # FIXME
+                      rm test/interactive-remove.sh # FIXME
                       sed -i \'s| defaultRegistryURL = .*;| defaultRegistryURL = "https://code-mirror.dlang.io/";|\' source/dub/dub.d
                       jq \'.versions["vibe-d"]="0.7.31"\' < dub.selections.json | sponge dub.selections.json
                       dub fetch ddox --version=0.16.0


### PR DESCRIPTION
Nearly every PR currently fails due to this

![image](https://user-images.githubusercontent.com/4370550/27505189-3e199398-589a-11e7-8f23-27a76a6367d0.png)

https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fphobos/activity

See also: https://github.com/dlang/dub/pull/1157

CC @CyberShadow - I think this should fix the Project-Tester and Martin has done a similar hack before ...