### PR TITLE
use Library to load pipeline.groovy script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,19 +1,5 @@
 #!/bin/env groovy
-
-def cloneUpstream () {
-    checkout(scm: [
-        $class: 'GitSCM',
-        branches: scm.branches,
-        extensions: scm.extensions + [[$class: 'CleanBeforeCheckout']],
-        userRemoteConfigs: scm.userRemoteConfigs
-    ])
-}
-
-def pipeline
-node {
-    dir('dlang/ci') {
-        cloneUpstream()
-    }
-    pipeline = load 'dlang/ci/pipeline.groovy'
-}
-pipeline.runPipeline()
+// use legacy checkout SCM to fetch library, so we test changes froms PRs/branches
+// https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/37#issuecomment-311608135
+library identifier: "dlang@master", retriever: legacySCM(scm)
+runPipeline()

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -235,7 +235,7 @@ def testDownstreamProject (name) {
 
 *******************************************************************************/
 
-def runPipeline() { timeout(time: 1, unit: 'HOURS') {
+def call() { timeout(time: 1, unit: 'HOURS') {
     /* Use the same workspace, no matter what job (dmd, druntime,...)  triggered
      * the build.  The workspace step will take care of concurrent test-runs and
      * allocate additional workspaces if necessary.  This setup avoids to


### PR DESCRIPTION
- avoids checkout of the whole ci repo
- temporarily added symlink for now to not break other dlang Jenkinsfiles