### PR TITLE
Add 'dlang/undeaD' to the pipeline

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -329,6 +329,7 @@ DFLAGS=-I%@P%/../imports -L-L%@P%/../libs -L--export-dynamic -L--export-dynamic 
         "DerelictOrg/DerelictGL3",
         "DerelictOrg/DerelictGLFW3",
         "DerelictOrg/DerelictSDL2",
+        "dlang/undeaD",
         "DlangScience/scid",
         "Netflix/vectorflow",
         "ariovistus/pyd",


### PR DESCRIPTION
Removing functions from Phobos can easily break undeaD. We need to prevent that if we want to continue to able to aggressively deprecate functionality that's not up to standards of Phobos.