### PR TITLE
Start testing Sociomantic ocean in pipeline

### DIFF
--- a/ansible/ci.yml
+++ b/ansible/ci.yml
@@ -78,7 +78,7 @@
   roles:
     - jenkins_slave
   tasks:
-    - name: test dependencies
+    - name: test dependencies (1/2)
       apt: { name: "{{ item }}", install_recommends: no, update_cache: yes, cache_valid_time: 3600 }
       with_items:
         - build-essential
@@ -87,12 +87,19 @@
         - git
         - jq
         - libblas-dev
+        - libbz2-dev
         - libcairo-dev
         - libcurl4-gnutls-dev
         - libevent-dev
+        - libgcrypt20-dev
+        - libgpg-error-dev
         - libgtk-3-0
         - liblapack-dev
+        - liblzo2-dev
+        - libreadline-dev
         - libssl-dev
+        - libxml2-dev
+        - libxslt1-dev
         - libzmq3-dev
         - mongodb-server
         - moreutils # sponge et.al.
@@ -103,6 +110,13 @@
         - redis-server
         - rsync
         - unzip
+      tags: deps
+    - name: test dependencies (2/2)
+      apt: { deb: "{{ item }}", install_recommends: no }
+      with_items:
+        - https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=libebtree6_6.0.socio6-xenial_amd64.deb
+        - https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=libebtree6-dev_6.0.socio6-xenial_amd64.deb
+        - https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=d1to2fix_0.10.0-alpha1-xenial_amd64.deb
       tags: deps
     - name: disable mongodb journaling
       lineinfile: { dest: /etc/mongodb.conf, regexp: "^{{ item.key }} *=", line: "{{ item.key }} = {{ item.value }}" }

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -151,7 +151,7 @@ def testDownstreamProject (name) {
                 if (repo == 'rejectedsoftware/vibe.d') {
                     clone("https://github.com/${repo}.git", 'v0.8.1-rc.1')
                 } else if (repo == "sociomantic-tsunami/ocean") {
-                    clone("https://github.com/${repo}.git", 'v4.0.0-alpha.1')
+                    clone("https://github.com/${repo}.git", 'v4.0.0-alpha.2')
                 } else {
                     cloneLatestTag("https://github.com/${repo}.git")
                 }

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -151,7 +151,7 @@ def testDownstreamProject (name) {
                 if (repo == 'rejectedsoftware/vibe.d') {
                     clone("https://github.com/${repo}.git", 'v0.8.1-rc.1')
                 } else if (repo == "sociomantic-tsunami/ocean") {
-                    clone("https://github.com/${repo}.git", "v4.0.0-alpha.0")
+                    clone("https://github.com/${repo}.git", 'v4.0.0-alpha.0')
                 } else {
                     cloneLatestTag("https://github.com/${repo}.git")
                 }
@@ -210,11 +210,11 @@ def testDownstreamProject (name) {
                     break;
 
                 case 'sociomantic-tsunami/ocean':
-                    sh """
+                    sh '''
                     git submodule update --init
                     make d2conv V=1
                     make test V=1 DVER=2 F=production
-                    """
+                    '''
                     break;
 
                 default:

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -151,7 +151,7 @@ def testDownstreamProject (name) {
                 if (repo == 'rejectedsoftware/vibe.d') {
                     clone("https://github.com/${repo}.git", 'v0.8.1-rc.1')
                 } else if (repo == "sociomantic-tsunami/ocean") {
-                    clone("https://github.com/${repo}.git", 'v4.0.0-alpha.0')
+                    clone("https://github.com/${repo}.git", 'v4.0.0-alpha.1')
                 } else {
                     cloneLatestTag("https://github.com/${repo}.git")
                 }
@@ -211,10 +211,9 @@ def testDownstreamProject (name) {
 
                 case 'sociomantic-tsunami/ocean':
                     sh '''
-                    sed -i '/^override DFLAGS += -de$/d' Build.mak
                     git submodule update --init
                     make d2conv V=1
-                    make test V=1 DVER=2 F=production
+                    make test V=1 DVER=2 F=production ALLOW_DEPRECATIONS=1
                     '''
                     break;
 

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -211,14 +211,9 @@ def testDownstreamProject (name) {
 
                 case 'sociomantic-tsunami/ocean':
                     sh """
-                    wget -O libebtree.deb https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=libebtree6_6.0.socio6-xenial_amd64.deb
-                    dpkg -x libebtree.deb libebtree/
-                    wget -O d1to2fix.deb https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=d1to2fix_0.10.0-alpha1-xenial_amd64.deb
-                    dpkg -x d1to2fix.deb d1to2fix/
-                    export PATH=\$PATH:\$PWD/d1to2fix/usr/bin/
                     git submodule update --init
                     make d2conv V=1
-                    make test V=1 DVER=2 F=production LDFLAGS=-L./libebtree/usr/lib/
+                    make test V=1 DVER=2 F=production
                     """
                     break;
 

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -327,6 +327,7 @@ DFLAGS=-I%@P%/../imports -L-L%@P%/../libs -L--export-dynamic -L--export-dynamic 
         // sorted by test time slow to fast
         "rejectedsoftware/vibe.d",
         "dlang/dub",
+        "sociomantic-tsunami/ocean",
         "higgsjs/Higgs",
         "BlackEdder/ggplotd",
         "atilaneves/unit-threaded",
@@ -335,7 +336,6 @@ DFLAGS=-I%@P%/../imports -L-L%@P%/../libs -L--export-dynamic -L--export-dynamic 
         "dlang-community/D-YAML",
         "CyberShadow/ae",
         "Hackerpilot/libdparse",
-        "sociomantic-tsunami/ocean",
         // run in under 10s, sorted alphabetically
         "Abscissa/libInputVisitor",
         "DerelictOrg/DerelictFT",

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -150,9 +150,12 @@ def testDownstreamProject (name) {
 
                 if (repo == 'rejectedsoftware/vibe.d') {
                     clone("https://github.com/${repo}.git", 'v0.8.1-rc.1')
+                } else if (repo == "sociomantic-tsunami/ocean") {
+                    clone("https://github.com/${repo}.git", "v4.0.0-alpha.0")
                 } else {
                     cloneLatestTag("https://github.com/${repo}.git")
                 }
+
                 switch (repo) {
                 case ['Hackerpilot/DCD', 'Hackerpilot/dfix']:
                     sh 'make DMD=$DMD'
@@ -204,6 +207,19 @@ def testDownstreamProject (name) {
                 case 'dlang-community/D-YAML':
                     sh 'dub build --compiler=$DC'
                     sh 'dub test --compiler=$DC'
+                    break;
+
+                case 'sociomantic-tsunami/ocean':
+                    sh """
+                    wget -O libebtree.deb https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=libebtree6_6.0.socio6-xenial_amd64.deb
+                    dpkg -x libebtree.deb libebtree/
+                    wget -O d1to2fix.deb https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=d1to2fix_0.10.0-alpha1-xenial_amd64.deb
+                    dpkg -x d1to2fix.deb d1to2fix/
+                    export PATH=\$PATH:\$PWD/d1to2fix/usr/bin/
+                    git submodule update --init
+                    make d2conv V=1
+                    make test V=1 DVER=2 F=production LDFLAGS=-L./libebtree/usr/lib/
+                    """
                     break;
 
                 default:
@@ -323,6 +339,7 @@ DFLAGS=-I%@P%/../imports -L-L%@P%/../libs -L--export-dynamic -L--export-dynamic 
         "dlang-community/D-YAML",
         "CyberShadow/ae",
         "Hackerpilot/libdparse",
+        "sociomantic-tsunami/ocean",
         // run in under 10s, sorted alphabetically
         "Abscissa/libInputVisitor",
         "DerelictOrg/DerelictFT",

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -211,6 +211,7 @@ def testDownstreamProject (name) {
 
                 case 'sociomantic-tsunami/ocean':
                     sh '''
+                    sed -i '/^override DFLAGS += -de$/d' Build.mak
                     git submodule update --init
                     make d2conv V=1
                     make test V=1 DVER=2 F=production


### PR DESCRIPTION
Recently (https://github.com/sociomantic-tsunami/ocean/pull/321) we have enabled CI testing with vanilla upstream DMD compiler for WIP ocean major branch, as 2.077 provided necessary `Throwable.message()`. 

Would appreciate getting it to the list of automatically tested projects ;)