### PR TITLE
Bump vibe-d to 0.8.3-alpha.1

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -149,7 +149,7 @@ def testDownstreamProject (name) {
             try { dir(repo) {
 
                 if (repo == 'rejectedsoftware/vibe.d') {
-                    clone("https://github.com/${repo}.git", 'v0.8.1-rc.1')
+                    clone("https://github.com/${repo}.git", 'v0.8.3-alpha.1')
                 } else if (repo == "sociomantic-tsunami/ocean") {
                     clone("https://github.com/${repo}.git", 'v4.0.0-alpha.2')
                 } else {


### PR DESCRIPTION
Vibe.d 0.8.3 won't include `std.experimental.allocator` anymore.

See also: https://github.com/vibe-d/vibe.d/pull/1983

Needed for https://github.com/dlang/phobos/pull/5921