### PR TITLE
[Vibe-d] Disable hanging test 1726 temporarily

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -172,6 +172,10 @@ def testDownstreamProject (name) {
                 case 'rejectedsoftware/vibe.d':
                     // use DC=dmd to workaround https://github.com/dlang/dub/pull/966
                     sh 'sed -i \'/# test building with Meson/,//d\' travis-ci.sh' // strip meson tests
+                    // temporarily disable failing tests, see: https://github.com/dlang/ci/pull/96
+                    sh 'rm -rf tests/vibe.core.net.1726' // FIXME
+                    sh 'rm -rf tests/std.concurrency' // FIXME
+
                     sh 'DC=dmd VIBED_DRIVER=libevent BUILD_EXAMPLE=1 RUN_TEST=1 ./travis-ci.sh'
                     sh 'DC=dmd VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0 ./travis-ci.sh || echo failed' // FIXME
                     break;


### PR DESCRIPTION
This test is permanently failing, see e.g.:

https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fphobos/detail/PR-5948/2/pipeline

```
Running ./tests 
core.exception.AssertError@source/app.d(58): Test has hung.
----------------
??:? _d_assert_msg [0x610b6a]
source/app.d:58 pure nothrow @nogc @safe void app.main().__lambda1() [0x555a50]
../../core/vibe/core/core.d:629 void vibe.core.core.makeTaskFuncInfo!(void delegate() @safe).makeTaskFuncInfo(ref void delegate() @safe).callDelegate(vibe.core.core.TaskFuncInfo*) [0x560f27]
../../core/vibe/core/core.d:1269 void vibe.core.core.CoreTask.run() [0x5655a6]
??:? void core.thread.Fiber.run() [0x6468a7]
??:? fiber_entryPoint [0x6465fa]
??:? [0xffffffff]
```

@s-ludwig's idea from #vibe-d-ci on Slack:

> Could it be that the server simply sometimes has higher load? I just had to adjust some tests because Travis tests started to fail often because timers didn't fire within the 20ms tolerance that was previously assumed. This test uses a 20 ms and a 100 ms sleep to generate a particular order, so it would be vulnerable to the same effects. (should probably be rewritten using some form of proper synchronization primitives - not sure how much work that would be)