### PR TITLE
Use master as fallback for non-existent branches

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -67,8 +67,12 @@ def cloneLatestTag (repo_url, filter = '') {
 /**
     Checks whether a specific branch exists at a remote git repository.
 */
-def doesBranchExist(repo_url, branch) {
-	"git ls-remote --exit-code --heads ${repo_url} ${branch} > /dev/null".execute().exitValue == 0
+def branchExists (repo_url, branch) {
+    def status = sh(
+        script: "git ls-remote --exit-code --heads ${repo_url} ${branch} > /dev/null",
+        returnStatus: true
+    )
+    return status == 0
 }
 
 /**
@@ -126,9 +130,9 @@ def getSources (name) { dir(name) {
         // target branch for PRs or identical branch name.
         def base_branch = env.CHANGE_TARGET ?: env.BRANCH_NAME
         def repo_url = "https://github.com/dlang/${name}.git"
-		if (doesBranchExist(repo_url, base_branch)) {
-			base_branch = "master"
-		}
+        if (!branchExists(repo_url, base_branch)) {
+            base_branch = 'master'
+        }
         clone(repo_url, base_branch)
     }
 }}

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -65,6 +65,13 @@ def cloneLatestTag (repo_url, filter = '') {
 }
 
 /**
+    Checks whether a specific branch exists at a remote git repository.
+*/
+def doesBranchExist(repo_url, branch) {
+	"git ls-remote --exit-code --heads ${repo_url} ${branch} > /dev/null".execute().exitValue == 0
+}
+
+/**
     Utility to simplify repeating boilerplate of defining parallel steps
     over array of folders. Creates a map from @names array where each value
     is @action called with each name respectively while being wrapped in
@@ -118,7 +125,11 @@ def getSources (name) { dir(name) {
         // Checkout matching branches of other repos, either
         // target branch for PRs or identical branch name.
         def base_branch = env.CHANGE_TARGET ?: env.BRANCH_NAME
-        clone("https://github.com/dlang/${name}.git", base_branch)
+        def repo_url = "https://github.com/dlang/${name}.git"
+		if (doesBranchExist(repo_url, base_branch)) {
+			base_branch = "master"
+		}
+        clone(repo_url, base_branch)
     }
 }}
 


### PR DESCRIPTION
When a PR is made directly from an upstream branch or to a different
branch than `master` or `stable`, the respective branch at the other two
repositories might not exist. So let's better check beforehand and
softly fallback to `master` otherwise. The same procedure is e.g. used
for CircleCi.

Note: I'm doing this more or less blind :/