### PR TITLE
Add dlang-bot to the tested projects

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -421,6 +421,7 @@ def call() { timeout(time: 1, unit: 'HOURS') {
         "DerelictOrg/DerelictGL3",
         "DerelictOrg/DerelictGLFW3",
         "DerelictOrg/DerelictSDL2",
+        "dlang-bots/dlang-bot",
         "DlangScience/scid",
         "Netflix/vectorflow",
         "PhilippeSigaud/Pegged",


### PR DESCRIPTION
It's currently broken again with `master`:

```
/home/seb/dlang/dmd/generated/linux/release/64/../../../../../phobos/std/algorithm/iteration.d-mixin-2498(2510,17): Error: cannot modify struct this._current Result with immutable members
source/dlangbot/bugzilla.d(43,9): Error: template instance std.algorithm.iteration.joiner!(MapResult!(__lambda2, Json[])) error instantiating
```

I will dig a bit into this issue, but once it's fixed, we should really add the dlang-bot to the projects tested.