### PR TITLE
temporarily remove unit-threaded until failure can be investigated

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -207,6 +207,12 @@ def testDownstreamProject (name) {
                     sh 'DC=dmd VIBED_DRIVER=libasync BUILD_EXAMPLE=0 RUN_TEST=0 ./travis-ci.sh || echo failed' // FIXME
                     break;
 
+                case 'atilaneves/unit-threaded':
+                    // FIXME: temporarily remove failing unit-threaded tests until they can be investigated
+                    // see: https://github.com/dlang/ci/pull/111
+                    sh './test.sh || echo failed' // FIXME
+                    break;
+
                 case 'rejectedsoftware/diet-ng':
                     sh 'sed -i \'/mkdir build && cd build/,//d\' .travis.yml' // strip meson tests
                     test_travis_yaml()


### PR DESCRIPTION
This is preventing some PRs from being merged.