### PR TITLE
Temporarily patch Ocean to workaround missing out contract patch

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -246,8 +246,11 @@ def testDownstreamProject (name) {
                     break;
 
                 case 'sociomantic-tsunami/ocean':
+                	// FIXME: https://github.com/sociomantic-tsunami/ocean/pull/427 is only applied for 3.x.x
+                	// See also: https://github.com/dlang/dmd/pull/7617
                     sh '''
                     git submodule update --init
+                    sed "/this.outer.occupied = false;/d" -i src/ocean/net/http/HttpResponse.d # FIXME
                     make d2conv V=1
                     make test V=1 DVER=2 F=production ALLOW_DEPRECATIONS=1
                     '''


### PR DESCRIPTION
The patch applied in https://github.com/sociomantic-tsunami/ocean/pull/427
doesn't seem to appear in Ocean `v4.0.0-alpha.4` anymore.

Currently it fails:

https://github.com/dlang/dmd/pull/7617

However, Jenkins did pass on
https://github.com/dlang/dmd/pull/7553 and e.g. on
https://github.com/dlang/phobos/pull/6002