### PR TITLE
Add dlang/tools to the tested projects

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -232,6 +232,12 @@ def testDownstreamProject (name) {
                     sh 'DC=$DC ./travis-ci.sh'
                     break;
 
+                case 'dlang/tools':
+                    // explicit test to avoid Digger setup, see dlang/tools#298 and dlang/tools#301
+                    sh "make -f posix.mak all DMD='${env.WORKSPACE}/distribution/bin/dmd'"
+                    sh "make -f posix.mak test DMD='${env.WORKSPACE}/distribution/bin/dmd' DFLAGS="
+                    break;
+
                 case 'msgpack/msgpack-d':
                     sh 'DMD=$DMD MODEL=64 make -f posix.mak unittest'
                     break;

--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -415,6 +415,7 @@ def call() { timeout(time: 1, unit: 'HOURS') {
         "dlang-community/DCD", // 23s
         "d-gamedev-team/gfm", // 28s
         "atilaneves/unit-threaded", //36s
+        "dlang/tools", // 40s
         "rejectedsoftware/diet-ng", // 56s
         "jacob-carlborg/dstep", // 1m16s
         "dlang-tour/core", // 1m17s


### PR DESCRIPTION
I just realized we don't run the testsuite of `dlang/tools`.