### PR TITLE
increase disk sizes to 30GiB

### DIFF
--- a/ansible/gce.yml
+++ b/ansible/gce.yml
@@ -15,7 +15,7 @@
         machine_type: n1-standard-8
         state: present
         image: ubuntu-1604
-        disk_size: 20
+        disk_size: 30
         persistent_boot_disk: true
         preemptible: true
         credentials_file: $XDG_RUNTIME_DIR/ansible@dlang-ci.iam.gserviceaccount.com


### PR DESCRIPTION
To accomodate the plenty of space that parallel vibe-d tests require.