### PR TITLE
Remove network tests for ae due to frequent timeouts

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -274,6 +274,12 @@ def testDownstreamProject (name) {
                     sh 'dub test --compiler=$DC'
                     break;
 
+                case 'CyberShadow/ae':
+                	// remove network tests (they tend to timeout)
+                	sh 'rm -f sys/net/test.d'
+                    test_travis_yaml()
+                    break;
+
                 default:
                     test_travis_yaml()
                     break;


### PR DESCRIPTION
```
Testing AENetwork
 - getFile
object.Exception@sys/net/ae.d(33): Time-out
----------------
sys/net/ae.d:33 pure @safe void ae.sys.net.ae.AENetwork.getData(immutable(char)[]).__lambda3(immutable(char)[]) [0x8f643b]
net/http/client.d:379 void ae.net.http.client.httpRequest(ae.net.http.common.HttpRequest, void delegate(ae.sys.data.Data), void delegate(immutable(char)[]), int).responseHandler(ae.net.http.common.HttpResponse, immutable(char)[]) [0x887377]
net/http/client.d:201 void ae.net.http.client.HttpClient.processResponse(immutable(char)[]) [0x886b16]
net/http/client.d:210 void ae.net.http.client.HttpClient.onDisconnect(immutable(char)[], ae.net.asockets.DisconnectType) [0x886b6a]
net/asockets.d:1398 void ae.net.asockets.ConnectionAdapter.onDisconnect(immutable(char)[], ae.net.asockets.DisconnectType) [0x7b66ba]
net/asockets.d:1589 void ae.net.asockets.TimeoutAdapter.onDisconnect(immutable(char)[], ae.net.asockets.DisconnectType) [0x7b70b1]
net/asockets.d:944 void ae.net.asockets.StreamConnection.disconnect(immutable(char)[], ae.net.asockets.DisconnectType) [0x7b4e58]
net/asockets.d:1380 void ae.net.asockets.ConnectionAdapter.disconnect(immutable(char)[], ae.net.asockets.DisconnectType) [0x7b6593]
net/asockets.d:1613 void ae.net.asockets.TimeoutAdapter.onTask_Idle(ae.sys.timing.Timer, ae.sys.timing.TimerTask) [0x7b71b0]
sys/timing.d:212 bool ae.sys.timing.Timer.prod() [0x90102b]
net/asockets.d:417 void ae.net.asockets.SocketManager.loop() [0x7b3a64]
sys/net/ae.d:36 ae.sys.data.Data ae.sys.net.ae.AENetwork.getData(immutable(char)[]) [0x8f62b3]
sys/net/ae.d:49 void[] ae.sys.net.ae.AENetwork.getFile(immutable(char)[]) [0x8f652b]
sys/net/test.d:39 void ae.sys.net.test.test!("ae", "AENetwork").test() [0x8fb7fa]
sys/net/test.d:75 void ae.sys.net.test.__unittest_ae_sys_net_test_73_0() [0x8fb6f0]
??:? void ae.sys.net.test.__modtest() [0x8fc294]
??:? int core.runtime.runModuleUnitTests().__foreachbody2(object.ModuleInfo*) [0xa4046f]
??:? int object.ModuleInfo.opApply(scope int delegate(object.ModuleInfo*)).__lambda2(immutable(object.ModuleInfo*)) [0x9dffa6]
??:? int rt.minfo.moduleinfos_apply(scope int delegate(immutable(object.ModuleInfo*))).__foreachbody2(ref rt.sections_elf_shared.DSO) [0x9ed025]
??:? int rt.sections_elf_shared.DSO.opApply(scope int delegate(ref rt.sections_elf_shared.DSO)) [0x9ed488]
??:? int rt.minfo.moduleinfos_apply(scope int delegate(immutable(object.ModuleInfo*))) [0x9ecfb1]
??:? int object.ModuleInfo.opApply(scope int delegate(object.ModuleInfo*)) [0x9dff7d]
??:? runModuleUnitTests [0xa40245]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0x9e768c]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0x9e7613]
??:? _d_run_main [0x9e757e]
??:? main [0x7b3119]
??:? __libc_start_main [0xf1c7f82f]
1/74 unittests FAILED
Program exited with code 1
script returned exit code 2
```

https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fdmd/detail/PR-7815/3/pipeline/

FYI @CyberShadow - imho this is the best course of action for now.
If you ever add a start a stub fileserver on the testsuite, please feel free to remove this.