### PR TITLE
Add kaleidicassociates/excel-d to tested projects

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -441,6 +441,7 @@ def call() { timeout(time: 1, unit: 'HOURS') {
         "DerelictOrg/DerelictGLFW3",
         "DerelictOrg/DerelictSDL2",
         "dlang-bots/dlang-bot",
+        "kaleidicassociates/excel-d",
         "DlangScience/scid",
         "Netflix/vectorflow",
         "PhilippeSigaud/Pegged",


### PR DESCRIPTION
One of Symmetry Investments sponsored projects. Tests are very quick to run so shouldn't cause much extra load.