### PR TITLE
Remove msgpack-d due to inactivity

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -448,7 +448,6 @@ def call() { timeout(time: 1, unit: 'HOURS') {
         "ikod/dlang-requests",
         "kyllingstad/zmqd",
         "lgvz/imageformats",
-        "msgpack/msgpack-d",
         "msoucy/dproto",
         "nomad-software/dunit",
         "repeatedly/mustache-d",


### PR DESCRIPTION
See https://github.com/dlang/dmd/pull/8241

Last PR was merged in 2017: https://github.com/msgpack/msgpack-d/pulls?q=is%3Apr+is%3Aclosed and the project seems generally unmaintained, e.g. https://github.com/msgpack/msgpack-d/pull/100

If there's active interest in the project, this PR can always easily be reverted.