### PR TITLE
Add dagon to the Project Tester

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -136,6 +136,7 @@ projects=(
     "BBasile/iz" # 12s
     "aliak00/optional" # 12s
     "dlang-community/dfmt" # 11s
+    "gecko0307/dagon" # TODO
     # run in under 10s sorted alphabetically
     "Abscissa/libInputVisitor"
     "ariovistus/pyd"

--- a/buildkite/load_distribution.sh
+++ b/buildkite/load_distribution.sh
@@ -22,3 +22,6 @@ export TEMP=$PWD/tmp
 
 export DC=dmd
 export DMD=dmd
+
+# At the moment all workers are x86_64
+export ARCH=x86_64


### PR DESCRIPTION
CC @gecko0307 are you okay with having a bit more testing of your projects?
For this to work, I think you need to update dlib, s.t. it doesn't use the removed `std.c` modules.
Then in the future, such hard breakage can't happen again.