### PR TITLE
Purge all dub packages

### DIFF
--- a/vars/runPipeline.groovy
+++ b/vars/runPipeline.groovy
@@ -337,6 +337,7 @@ def testDownstreamProject (name) {
             finally {
                 sh """
                 dub clean --all-packages >/dev/null
+                rm -rf ~/.dub # remove the invalid vibe-core 1.4.1 package
                 # workaround https://github.com/dlang/dub/issues/1256
                 if [ -d '${env.WORKSPACE}/.dub/packages' ]; then
                     find '${env.WORKSPACE}/.dub/packages' -type f -name '*.a' -delete


### PR DESCRIPTION
Sönke retagged 1.4.1 and I think there's still an invalid copy of it laying around.

See also: https://ci.dlang.io/blue/organizations/jenkins/dlang-org%2Fci/detail/PR-225/52/pipeline