### PR TITLE
Add libopenblas-dev to the buildkite agents

### DIFF
--- a/ansible/ci.yml
+++ b/ansible/ci.yml
@@ -134,6 +134,7 @@
         - libgtk-3-0
         - liblapack-dev
         - liblzo2-dev
+        - libopenblas-dev
         - libreadline-dev
         - libssl-dev
         - libxml2-dev


### PR DESCRIPTION
Apparentely lubeck needs this since the recent 0.1: https://buildkite.com/dlang/dmd/builds/202#14a669e8-1d9d-4e32-ac49-79c6d5e71b17