### PR TITLE
Avoid accidentally opening new log sections with bash's tracing output

### DIFF
--- a/buildkite/build_distribution.sh
+++ b/buildkite/build_distribution.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+PS4="~> " # needed to avoid accidentally generating collapsed output
 set -uexo pipefail
 
 # Builds DMD, DRuntime, Phobos, tools and DUB + creates a "distribution" archive for latter usage.

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+PS4="~> " # needed to avoid accidentally generating collapsed output
 set -uexo pipefail
 
 echo "--- Setting build variables"


### PR DESCRIPTION
Buildkite interprets `+++` as new group that should be opened.
This simply sets `PS4` to a different symbol, s.t. no groups are
accidentally opened.

See also: https://buildkite.com/docs/builds/managing-log-output#collapsing-output