### PR TITLE
Run CodeCov on Buildkite

### DIFF
--- a/buildkite/build_distribution.sh
+++ b/buildkite/build_distribution.sh
@@ -8,46 +8,7 @@ echo "--- Setting build variables"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-origin_repo="$(echo "$BUILDKITE_REPO" | sed "s/.*\/\([^\]*\)[.]git/\1/")"
-origin_target_branch="$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
-if [ -z "$origin_target_branch" ] ; then
-  origin_target_branch="$BUILDKITE_BRANCH"
-fi
-echo "origin_target_branch: $origin_target_branch"
-
-echo "--- Cloning all core repositories"
-repositories=(dmd druntime phobos tools dub)
-for dir in "${repositories[@]}" ; do
-    if [ "$origin_repo" == "$dir" ] ; then
-      # we have already cloned this repo, so let's use this data
-        mkdir -p "$dir"
-        for f in ./* ; do
-            case "$f" in
-                ./.git) ;;
-                ./buildkite) ;;
-                "./${dir}") ;;
-                *)
-                    mv "$f" "$dir"
-                    ;;
-            esac
-        done
-    fi
-done
-for dir in "${repositories[@]}" ; do
-    if [ "$origin_repo" != "$dir" ] ; then
-        if [ "$origin_target_branch" == "master" ] || [ "$origin_target_branch" == "stable" ] ; then
-            branch="$origin_target_branch"
-        else
-            branch=$(git ls-remote --exit-code --heads "https://github.com/dlang/$dir" "${origin_target_branch}" > /dev/null && echo "$origin_target_branch" || echo "master")
-        fi
-        git clone -b "${branch:-master}" --depth 1 "https://github.com/dlang/$dir"
-    fi
-done
-
-for dir in dmd druntime phobos ; do
-    echo "--- Building $dir"
-    make -C $dir -f posix.mak AUTO_BOOTSTRAP=1 --jobs=4
-done
+"$DIR/clone_repositories.sh"
 
 echo "--- Building dub"
 cd dub

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+PS4="~> " # needed to avoid accidentally generating collapsed output
+set -uexo pipefail
+
+# Builds DMD, DRuntime, Phobos, tools and DUB + creates a "distribution" archive for latter usage.
+echo "--- Setting build variables"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+origin_repo="$(echo "$BUILDKITE_REPO" | sed "s/.*\/\([^\]*\)[.]git/\1/")"
+origin_target_branch="$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
+if [ -z "$origin_target_branch" ] ; then
+  origin_target_branch="$BUILDKITE_BRANCH"
+fi
+echo "origin_target_branch: $origin_target_branch"
+
+echo "--- Cloning all core repositories"
+repositories=(dmd druntime phobos tools dub)
+for dir in "${repositories[@]}" ; do
+    if [ "$origin_repo" == "$dir" ] ; then
+    # we have already cloned this repo, so let's use this data
+        mkdir -p "$dir"
+        for f in ./* ; do
+            case "$f" in
+                ./.git) ;;
+                ./buildkite) ;;
+                "./${dir}") ;;
+                *)
+                    mv "$f" "$dir"
+                    ;;
+            esac
+        done
+    fi
+done
+
+for dir in "${repositories[@]}" ; do
+    if [ "$origin_repo" != "$dir" ] ; then
+        if [ "$origin_target_branch" == "master" ] || [ "$origin_target_branch" == "stable" ] ; then
+            branch="$origin_target_branch"
+        else
+            branch=$(git ls-remote --exit-code --heads "https://github.com/dlang/$dir" "${origin_target_branch}" > /dev/null && echo "$origin_target_branch" || echo "master")
+        fi
+        git clone -b "${branch:-master}" --depth 1 "https://github.com/dlang/$dir"
+    fi
+done
+
+for dir in dmd druntime phobos ; do
+    echo "--- Building $dir"
+    make -C $dir -f posix.mak AUTO_BOOTSTRAP=1 --jobs=4
+done

--- a/buildkite/test_coverage.sh
+++ b/buildkite/test_coverage.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+PS4="~> " # needed to avoid accidentally generating collapsed output
+set -uexo pipefail
+
+echo "--- Setting build variables"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+N=2
+MODEL=64
+PIC=1
+
+"$DIR/clone_repositories.sh"
+
+echo "--- Running the testsuite with COVERAGE=1"
+
+origin_repo="$(echo "$BUILDKITE_REPO" | sed "s/.*\/\([^\]*\)[.]git/\1/")"
+cd "$origin_repo"
+
+if [ -f coverage.sh ] ; then
+    wget "https://codecov.io/bash" -O codecov.sh
+    ./coverage.sh
+else
+    echo "WARNING: no coverage.sh script found."
+fi


### PR DESCRIPTION
A first step at fixing https://github.com/dlang/ci/issues/19.
The idea is to unite a few CIs and CircleCi is one of easier.

However, we probably want to define the exact Coverage steps as a `coverage` target in the individual repositories (or maybe even as a `codecov` target as the submit step is also different.) -> `codecov.sh` script