### PR TITLE
Don't move the buildkite folder when creating the distribution

### DIFF
--- a/buildkite/build_distribution.sh
+++ b/buildkite/build_distribution.sh
@@ -24,6 +24,7 @@ for dir in "${repositories[@]}" ; do
         for f in ./* ; do
             case "$f" in
                 ./.git) ;;
+                ./buildkite) ;;
                 "./${dir}") ;;
                 *)
                     mv "$f" "$dir"


### PR DESCRIPTION
Just to be safe and in case it's needed in the future.