### PR TITLE
Temporarily disable unit-threaded

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -60,7 +60,7 @@ projects=(
     "rejectedsoftware/diet-ng" # 56s
     "mbierlee/poodinis" # 40s
     "dlang/tools" # 40s
-    "atilaneves/unit-threaded" #36s
+    #"atilaneves/unit-threaded" #36s
     "d-gamedev-team/gfm" # 28s
     "dlang-community/DCD" # 23s
     "weka-io/mecca" # 22s


### PR DESCRIPTION
Looking at the logs it seems that unit-threaded doesn't build anymore.

CC @atilaneves

e.g. https://buildkite.com/dlang/ci/builds/173#cfaf1389-9f04-415f-8d70-ed5196491cdb

```
Linking...
TERM environment variable not set.
```