### PR TITLE
Revert "Temporarily disable unit-threaded"

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -138,7 +138,7 @@ projects=(
     "rejectedsoftware/diet-ng" # 56s
     "mbierlee/poodinis" # 40s
     "dlang/tools" # 40s
-    #"atilaneves/unit-threaded" #36s
+    "atilaneves/unit-threaded" #36s
     "d-gamedev-team/gfm" # 28s
     "gecko0307/dagon" # 25s
     "dlang-community/DCD" # 23s

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -295,6 +295,11 @@ case "$REPO_FULL_NAME" in
         use_travis_test_script
         ;;
 
+    atilaneves/unit-threaded)
+        export TERM="${TERM:-xterm-256color}"
+        use_travis_test_script
+        ;;
+
     *)
         use_travis_test_script
         ;;


### PR DESCRIPTION
Reverts dlang/ci#269 (can be enabled once the unit-threaded build errors have been resolved.)

CC @atilaneves 