### PR TITLE
Make LDC master build itself, using ninja

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -99,6 +99,7 @@ projects=(
     "vibe-d/vibe.d+vibe-core-examples" # 9m51s
     "vibe-d/vibe.d+libevent-tests" # 8m35s
     "vibe-d/vibe.d+vibe-core-tests" # 6m44s
+    "ldc-developers/ldc" # 4m49s
     "vibe-d/vibe.d+libevent-base" # 4m20s
     "vibe-d/vibe.d+vibe-core-base" # 4m31s
     # https://github.com/vibe-d/vibe.d/issues/2157
@@ -109,7 +110,6 @@ projects=(
     "vibe-d/vibe-core+select" # 3m30s
     "higgsjs/Higgs" # 3m10s
     "rejectedsoftware/ddox" # 2m42s
-    "ldc-developers/ldc" # 2m15s
     "BlackEdder/ggplotd" # 1m56s
     "LaurentTreguier/dls" # 1m55s
     "eBay/tsv-utils" # 1m41s

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -33,6 +33,10 @@ case "$REPO_URL" in
         # for https://github.com/vibe-d/vibe.d/pull/2183, required until 0.8.5 is released
         latest_tag=master
         ;;
+    https://github.com/ldc-developers/ldc)
+        # ldc doesn't really do point releases, so master is easier to adapt if needed.
+        latest_tag=master
+        ;;
     *)
         ;;
 esac
@@ -206,10 +210,16 @@ case "$REPO_FULL_NAME" in
         ;;
 
     ldc-developers/ldc)
-        git submodule update --init
+        cd runtime && git clone --depth 5 https://github.com/ldc-developers/druntime
+        git clone --depth 5 https://github.com/ldc-developers/phobos
+        cd .. && git submodule update
+        mkdir bootstrap && cd bootstrap
+        cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DD_COMPILER="$DC" ..
+        ninja -j2 ldmd2 druntime-ldc-debug phobos2-ldc-debug
+        cd ..
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DD_COMPILER="$DC" ..
-        make -j2 ldc2
+        cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DD_COMPILER="$(pwd)/../bootstrap/bin/ldmd2" ..
+        ninja -j2 ldc2 druntime-ldc phobos2-ldc
         ;;
 
     *)


### PR DESCRIPTION
@kinke noted when updating ldc that the issue was with a self-compiled ldc crashing because of some C++ interfacing issues, so I tried to recreate that as much as possible. This will make this test run more than twice as long, but I'm not sure the previous version would have caught C++ interfacing issues.