### PR TITLE
Add dls to the project tester

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -103,6 +103,7 @@ projects=(
     "rejectedsoftware/ddox" # 2m42s
     "ldc-developers/ldc" # 2m15s
     "BlackEdder/ggplotd" # 1m56s
+    "LaurentTreguier/dls" # 1m55s
     "eBay/tsv-utils" # 1m41s
     "dlang-community/D-Scanner" # 1m40s
     "dlang-tour/core" # 1m17s


### PR DESCRIPTION
As it's becoming more hyped on the forums and we want to avoid breaking high-impact tools with new DMD releases.

CC @LaurentTreguier - there should be nothing required on your side (this is just an FYI).
The project tester will automatically test the latest (stable) released version and use the same testing scripts as you have defined in your `.travis.yml`.

The Buildkite account is still private, but you can use the dummy account (dummy@dlang.io, "dlangrocks") to browse the logs.)