### PR TITLE
Temporarily disable dxml

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -124,7 +124,7 @@ projects=(
     "dlang-community/DCD" # 23s
     "weka-io/mecca" # 22s
     "CyberShadow/ae" # 22s
-    "jmdavis/dxml" # 22s
+    #"jmdavis/dxml" # 22s
     "libmir/mir-algorithm" # 17s
     "dlang-community/D-YAML" # 15s
     "libmir/mir-random" # 13s


### PR DESCRIPTION
Until the breakage has been resolved, e.g.

https://buildkite.com/dlang/phobos/builds/180#3399564a-7cc7-4850-955c-101f35d33b6b

FYI: @jmdavis

This looks like the skipOver PR https://github.com/dlang/phobos/pull/6143 introduced a breakage in your dxml library.
I will for now disable dxml and then immediately open the revert, s.t. we can enable it later (once the regression has been fixed.)