### PR TITLE
Fix Phobos (v2)

### DIFF
--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -35,7 +35,7 @@ for dir in "${repositories[@]}" ; do
 done
 
 for dir in "${repositories[@]}" ; do
-    if [ ! -d "$origin_repo" ] ; then
+    if [ ! -d "$dir" ] ; then
         if [ "$origin_target_branch" == "master" ] || [ "$origin_target_branch" == "stable" ] ; then
             branch="$origin_target_branch"
         else


### PR DESCRIPTION
We really need a better way to simulate dmd/druntime/phobos builds for the ci repository.
Maybe we can just add them as separate pipelines to the CI repo? But I guess checking out the respective PR and the branch logic might not work then...