### PR TITLE
Revert "Disable LDC until the recent failure has been resolved"

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -113,7 +113,7 @@ projects=(
     "vibe-d/vibe-core+select" # 3m30s
     "higgsjs/Higgs" # 3m10s
     "rejectedsoftware/ddox" # 2m42s
-    #"ldc-developers/ldc" # 2m15s
+    "ldc-developers/ldc" # 2m15s
     "BlackEdder/ggplotd" # 1m56s
     "LaurentTreguier/dls" # 1m55s
     "eBay/tsv-utils" # 1m41s


### PR DESCRIPTION
Reverts dlang/ci#298

s.t. we have time to figure out the failure without affecting the CI infrastructure and creating failing builds for all contributors.