### PR TITLE
Increase the buildkite-agents priority

### DIFF
--- a/ansible/ci.yml
+++ b/ansible/ci.yml
@@ -130,7 +130,7 @@
     - vars/passwords.yml # buildkite_agent_token
   roles:
     - role: buildkite_agent
-      priority: 1
+      priority: 5 # Higher priority agents are assigned work first
       tags: buildkite_agent
 
 - hosts: ci.dlang.io

--- a/ansible/roles/buildkite_agent/defaults/main.yml
+++ b/ansible/roles/buildkite_agent/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 agent_version: 3.4.0
-priority: 0
+priority: 5 # Higher priority agents are assigned work first
 stop_timeout: 5min # systemd TimeoutStopSec for graceful agent shutdown


### PR DESCRIPTION
Higher priority agents are assigned work first.

See also: https://buildkite.com/docs/agent/v3/prioritization