### PR TITLE
Fix #308 - wrong version of Phobos is checked out during testing it as a project

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -41,7 +41,7 @@ case "$REPO_URL" in
         ;;
 esac
 
-# Don't checkout a tagged version of the core repostories like Phobos
+# Don't checkout a tagged version of the core repositories like Phobos
 case "$REPO_FULL_NAME" in
     dlang/phobos)
         ;;

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -9,8 +9,6 @@ echo "--- Setting build variables"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 origin_repo="$(echo "$BUILDKITE_REPO" | sed "s/.*\/\([^\]*\)[.]git/\1/")"
-origin_target_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-$BUILDKITE_BRANCH}"
-echo "origin_target_branch: $origin_target_branch"
 
 echo "--- Cloning all core repositories"
 repositories=(dmd druntime phobos tools dub)
@@ -36,12 +34,10 @@ done
 
 for dir in "${repositories[@]}" ; do
     if [ ! -d "$dir" ] ; then
-        if [ "$origin_target_branch" == "master" ] || [ "$origin_target_branch" == "stable" ] ; then
-            branch="$origin_target_branch"
-        else
-            branch=$(git ls-remote --exit-code --heads "https://github.com/dlang/$dir" "${origin_target_branch}" > /dev/null && echo "$origin_target_branch" || echo "master")
-        fi
-        git clone -b "${branch:-master}" --depth 1 "https://github.com/dlang/$dir"
+        repo="https://github.com/dlang/$dir"
+        branch=$("$DIR/origin_target_branch.sh" "$repo")
+        echo "target_branch: $branch"
+        git clone -b "${branch:-master}" --depth 1 "$repo"
     fi
 done
 

--- a/buildkite/origin_target_branch.sh
+++ b/buildkite/origin_target_branch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Returns the origin target branch to clone
+
+origin_target_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-$BUILDKITE_BRANCH}"
+
+repo="$1"
+
+if [ -e "$repo" ] ; then
+    (>&2 echo "Did you forget to pass in a repository?")
+    exit 1
+fi
+
+branch=master
+
+if [ "$origin_target_branch" == "master" ] || [ "$origin_target_branch" == "stable" ] ; then
+    branch="$origin_target_branch"
+else
+    # check whether the current branch exists on the to be checked out repo
+    branch=$(git ls-remote --exit-code --heads "$repo" "${origin_target_branch}" > /dev/null && echo "$origin_target_branch" || echo "master")
+fi
+echo "$branch"


### PR DESCRIPTION
The problem was that when Phobos (or dub or tools for that matter) is tested as a project, it used the same logic as all the other to-be-tested projects (i.e. fetching and checking out the latest tag).

With this PR the core repositories will use the same logic as its existing in the build_distribution step:
- merge the PR head into the target branch (if it's the same repo)
- otherwise check if the branch from the repo that triggered the PR exists in the to-be-tested repo (master and stable always exist)
- otherwise checkout master