### PR TITLE
Disable failing vibe.d (with vibe-core) jobs until eventcore is fixed

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -130,21 +130,27 @@ case "$REPO_FULL_NAME" in
         VIBED_DRIVER=vibe-core PARTS=examples ./travis-ci.sh
         ;;
     vibe-d/vibe.d+vibe-core-tests)
-        remove_spurious_vibed_tests
-        VIBED_DRIVER=vibe-core PARTS=tests ./travis-ci.sh
+        # disabled due to https://github.com/vibe-d/eventcore/pull/86
+        echo "DISABLED"
+        #remove_spurious_vibed_tests
+        #VIBED_DRIVER=vibe-core PARTS=tests ./travis-ci.sh
         ;;
     vibe-d/vibe.d+libasync-base)
         VIBED_DRIVER=libasync PARTS=builds,unittests ./travis-ci.sh
         ;;
 
     vibe-d/vibe-core+epoll)
+        # disabled due to https://github.com/vibe-d/eventcore/pull/86
+        echo "DISABLED"
         rm tests/issue-58-task-already-scheduled.d # https://github.com/vibe-d/vibe-core/issues/84
-        CONFIG=epoll ./travis-ci.sh
+        #CONFIG=epoll ./travis-ci.sh
         ;;
 
     vibe-d/vibe-core+select)
+        # disabled due to https://github.com/vibe-d/eventcore/pull/86
+        echo "DISABLED"
         rm tests/issue-58-task-already-scheduled.d # https://github.com/vibe-d/vibe-core/issues/84
-        CONFIG=select ./travis-ci.sh
+        #CONFIG=select ./travis-ci.sh
         ;;
 
     dlang/dub)


### PR DESCRIPTION
https://github.com/vibe-d/eventcore/pull/86 broke these jobs (see e.g. https://buildkite.com/dlang/ci/builds/447#20a4e124-5d52-4281-8ca5-4268b21af56b)

This temporarily disables the builds and I will revert this immediately afterwards, s.t. we can reenable it once fixed.