### PR TITLE
slightly increase job timeout

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -26,7 +26,7 @@ EOM
 
 read -r -d '' DEFAULT_COMMAND_PROPS <<- EOM
     branches: !dmd-cxx
-    timeout_in_minutes: 30
+    timeout_in_minutes: 40
     retry:
       automatic:
         limit: 2


### PR DESCRIPTION
- for vibe.d examples

See https://buildkite.com/dlang/dub/builds/229#6f781f60-ea4c-451b-b5d5-56318978ebb3 for a failure.