### PR TITLE
Rename LaurentTreguier/dls -> d-language-server/dls

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -117,7 +117,7 @@ projects=(
     "higgsjs/Higgs" # 3m10s
     "rejectedsoftware/ddox" # 2m42s
     "BlackEdder/ggplotd" # 1m56s
-    "LaurentTreguier/dls" # 1m55s
+    "d-language-server/dls" # 1m55s
     "eBay/tsv-utils" # 1m41s
     "dlang-community/D-Scanner" # 1m40s
     "dlang/druntime" # 1m18s
@@ -184,7 +184,7 @@ memory_req["dlang-bots/dlang-bot"]=high
 memory_req["dlang/phobos"]=high
 memory_req["dlang/dub"]=high
 memory_req["higgsjs/Higgs"]=high
-memory_req["LaurentTreguier/dls"]=high
+memory_req["d-language-server/dls"]=high
 
 for project_name in "${projects[@]}" ; do
     project="$(echo "$project_name" | sed "s/\([^+]*\)+.*/\1/")"


### PR DESCRIPTION
After https://github.com/d-language-server/dls/pull/17, dls now doesn't have a fixed dub version in `dub.selections.json` anymore, but I'm not entirely satisfied with simply removing it, for three reasons:
- it goes against reproducible builds, which is something I prefer having (in case I need to find out about a regression somewhere or anything)
- when launching a simple build, dub rewrites `dub.selections.json` with all the required dependencies, adding the `dub` line again and automatically dirtying the file in the process
- I'm an airhead, and I might just re-add the line in the repo by accident when upgrading other dependencies

The 2 commits in this PR:
- rename the repository (as I moved it and other related repos under an organization)
- add an entry in `build_project.sh` to erase the `dub` line from `dub.selections.json` for dls, and let dub pick the appropriate version instead