### PR TITLE
Copy over .git to current repository

### DIFF
--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -19,7 +19,10 @@ for dir in "${repositories[@]}" ; do
         mkdir -p "$dir"
         for f in ./* ; do
             case "$f" in
-                ./.git) ;;
+                ./.git)
+                    # for some commands a real "git" repository is required
+                    cp -r "$f" "$dir"
+                    ;;
                 ./buildkite) ;;
                 ./distribution) ;;
                 ./tmp) ;;


### PR DESCRIPTION
At the moment the druntime style target is failing because it requires `git ls-tree` to work (see e.g. https://github.com/dlang/druntime/pull/2380).

The reason why `git ls-tree` doesn't work is that the `.git` simply doesn't exist.

Long explanation:

When we try to create the actual D core repository structure in the Buildkite repo, we can't go up in the file hierarchy. Thus, we go "down" by moving the content of the currently checkout out PR in its respective subfolder and clone the respective target branch (master, stable, etc.) from the other required core repositories.
See `clone_repositories` for details.

For now, `.git` wasn't moved to keep at least the main repository cached, but a workaround here is to copy the `.git` folder over.

A better long-term solution would be to use custom git checkout commands, s.t. we can cache more and avoid this rather frickle process of creating the core repository layout.