### PR TITLE
reduce number of buildkite agents on ci server

### DIFF
--- a/ansible/inventories/static
+++ b/ansible/inventories/static
@@ -8,7 +8,7 @@ ci_containers
 [ci_containers]
 jenkins.ci.dlang.io
 dub-registry.ci.dlang.io
-buildkite-agent-[01:08].ci.dlang.io
+buildkite-agent-[01:04].ci.dlang.io
 
 [ci_containers:vars]
 jenkins_use_github_auth=True
@@ -24,7 +24,7 @@ buildkite_demand_agents
 
 # permanent buildkite agents
 [buildkite_permanent_agents]
-buildkite-agent-[01:08].ci.dlang.io
+buildkite-agent-[01:04].ci.dlang.io
 
 # on-demand buildkite agents
 [buildkite_demand_agents]


### PR DESCRIPTION
- to prepare slow phase-out