### PR TITLE
Move/copy hidden files of the base repository when needing to clone all core repositories

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -153,6 +153,9 @@ case "$REPO_FULL_NAME" in
             echo "Current commit: $(git describe --always)"
             [[ "$(git log --format=%B -n 1)" =~ Merge[[:space:]]${BUILDKITE_COMMIT:-invalid} ]]
         fi
+        echo "--- Test cloning all core repositories"
+        "$DIR"/clone_repositories.sh
+        ( cd ci && [[ "$(git log --format=%B -n 1)" =~ Merge[[:space:]]${BUILDKITE_COMMIT:-invalid} ]])
         ;;
 
     dlang/dub)

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -19,8 +19,7 @@ if [ "${REPO_FULL_NAME:-none}" == "dlang/ci" ] ; then
 fi
 
 for dir in "${repositories[@]}" ; do
-    # repos cloned via the project tester can't be considered as existent
-    if [ "$origin_repo" == "$dir" ] && [ "${REPO_FULL_NAME:-x}" == "x" ]  ; then
+    if [ "$origin_repo" == "$dir" ] ; then
     # we have already cloned this repo, so let's use this data
         mkdir -p "$dir"
         for f in ./* ; do

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -12,6 +12,12 @@ origin_repo="$(echo "$BUILDKITE_REPO" | sed "s/.*\/\([^\]*\)[.]git/\1/")"
 
 echo "--- Cloning all core repositories"
 repositories=(dmd druntime phobos tools dub)
+
+# For PRs to dlang/ci, clone itself too, s.t. the code below can be tested
+if "${REPO_FULL_NAME:-none}" == "dlang/ci" ; then
+    repositories+=(ci)
+fi
+
 for dir in "${repositories[@]}" ; do
     # repos cloned via the project tester can't be considered as existent
     if [ "$origin_repo" == "$dir" ] && [ "${REPO_FULL_NAME:-x}" == "x" ]  ; then

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -22,7 +22,7 @@ for dir in "${repositories[@]}" ; do
     if [ "$origin_repo" == "$dir" ] ; then
     # we have already cloned this repo, so let's use this data
         mkdir -p "$dir"
-        for f in ./* ; do
+        find . -maxdepth 1 -mindepth 1 | while read -r f ; do
             case "$f" in
                 ./.git)
                     # for some commands a real "git" repository is required

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -14,7 +14,7 @@ echo "--- Cloning all core repositories"
 repositories=(dmd druntime phobos tools dub)
 
 # For PRs to dlang/ci, clone itself too, s.t. the code below can be tested
-if "${REPO_FULL_NAME:-none}" == "dlang/ci" ; then
+if [ "${REPO_FULL_NAME:-none}" == "dlang/ci" ] ; then
     repositories+=(ci)
 fi
 


### PR DESCRIPTION
The reason https://github.com/dlang/ci/pull/346 didn't work was that the `for f in ./* ; do` doesn't match hidden files and thus still didn't copy `.git` over.
An alternative would be `ls -a` or `find`.