### PR TITLE
fix(clone_repos): only moves files of the repository from which the PR originated

### DIFF
--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -19,7 +19,10 @@ if [ "${REPO_FULL_NAME:-none}" == "dlang/ci" ] ; then
 fi
 
 for dir in "${repositories[@]}" ; do
-    if [ "$origin_repo" == "$dir" ] ; then
+    # repos cloned via the project tester can't be considered as existent
+    # except its the repository from which the PR was triggered
+    if [ "$origin_repo" == "$dir" ] &&
+        { [ "${REPO_FULL_NAME:-x}" == "x" ] || [ "$(basename "${REPO_FULL_NAME:-x}")" == "$origin_repo" ] ; }  ; then
     # we have already cloned this repo, so let's use this data
         mkdir -p "$dir"
         find . -maxdepth 1 -mindepth 1 | while read -r f ; do


### PR DESCRIPTION
Yet another attempt at fixing Buildkite.