### PR TITLE
fix(buildkite): only self-test for PRs to dlang/ci

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -187,7 +187,9 @@ memory_req["higgsjs/Higgs"]=high
 memory_req["d-language-server/dls"]=high
 
 # self-test PRs to dlang/ci
-projects+=("dlang/ci")
+if [[ "${BUILDKITE_REPO:-b}" =~ ^https://github.com/dlang/ci([.]git)?$ ]] ; then
+    projects+=("dlang/ci")
+fi
 
 for project_name in "${projects[@]}" ; do
     project="$(echo "$project_name" | sed "s/\([^+]*\)+.*/\1/")"


### PR DESCRIPTION
There's no real point in testing Buildkite when run e.g. at dmd.