### PR TITLE
debug: list the entire directory layout when testing an already checked out core project

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -78,6 +78,9 @@ if [ "$latest_tag" != "IS-ALREADY-CHECKED-OUT" ] ; then
     echo "--- Cloning ${REPO_URL} (tag: $latest_tag)"
     git clone -b "${latest_tag}" --depth 1 "${REPO_URL}" "${REPO_DIR}"
     cd "${REPO_DIR}"
+else
+    # list the entire directory layout for debugging
+    ls -R
 fi
 
 use_travis_test_script()


### PR DESCRIPTION
This needs to be in master for it to take effect, but at the moment I don't know why dlang/dub is failing at dlang/dub (or dlang/druntime at dlang/druntime).