### PR TITLE
Fix clone_repositories if a project repository triggered the build

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -81,6 +81,8 @@ if [ "$latest_tag" != "IS-ALREADY-CHECKED-OUT" ] ; then
 else
     # list the entire directory layout for debugging
     ls -R
+    echo "--- Reusing existing layout for ${REPO_URL}"
+    cd ..
 fi
 
 use_travis_test_script()

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -31,6 +31,7 @@ for dir in "${repositories[@]}" ; do
                     # for some commands a real "git" repository is required
                     cp -r "$f" "$dir"
                     ;;
+                ./build) ;;
                 ./buildkite) ;;
                 ./distribution) ;;
                 ./tmp) ;;


### PR DESCRIPTION
If a project triggers a PR (e.g. dlang/phobos), then it shouldn't be recloned
if dlang/phobos needs to be tested. This logic is already in `build_project`
and `clone_repositories`.

At the moment, builds are done in the subfolder `build`, but the
`clone_repositories` script assumes that we're at the git root folder.

This should fix many of the remaining Buildkite failures (maybe even #355).