### PR TITLE
Only run the second dlang/ci test for PRs

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -168,7 +168,9 @@ case "$REPO_FULL_NAME" in
         fi
         echo "--- Test cloning all core repositories"
         "$DIR"/clone_repositories.sh
-        ( cd ci && [[ "$(git log --format=%B -n 1)" =~ Merge[[:space:]]${BUILDKITE_COMMIT:-invalid} ]])
+        if [ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]; then
+            ( cd ci && [[ "$(git log --format=%B -n 1)" =~ Merge[[:space:]]${BUILDKITE_COMMIT:-invalid} ]])
+        fi
         ;;
 
     dlang/dub)


### PR DESCRIPTION
We could also check that on `master` the last commit is "Merge pull request ...",
but as this generally doesn't have to be, it's probably not worth adding this
incorrect general assumption.

Also, this test was solely added to be able to test clone_repositories for projects
when submitting a new PR to dlang/ci.

This should unbreak the broken master build for dlang/ci

https://buildkite.com/dlang/ci/builds/574#74f63286-dfd5-4cb3-bd8d-95d74f81e02c