### PR TITLE
Force-clean git repository before building

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -16,6 +16,8 @@ read -r -d '' LOAD_CI_FOLDER <<- EOM
 EOM
 
 read -r -d '' LOAD_DISTRIBUTION <<- EOM
+        # just to be sure there isn't anything old left
+        git clean -ffdxq .
         echo "--- Load distribution archive"
         buildkite-agent artifact download distribution.tar.xz .
         tar xfJ distribution.tar.xz


### PR DESCRIPTION
This should help to avoid spurious failures when there are left-overs from previous builds.

(We already use it for almost all targets except for e.g. "style".)