### PR TITLE
Increase timeout to 60 minutes

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -28,7 +28,7 @@ EOM
 
 read -r -d '' DEFAULT_COMMAND_PROPS <<- EOM
     branches: !dmd-cxx
-    timeout_in_minutes: 40
+    timeout_in_minutes: 60
     retry:
       automatic:
         limit: 2


### PR DESCRIPTION
The on-demand provided Buildkite agents seem to be really slow.