### PR TITLE
enable dub's experimental build cache improvements

### DIFF
--- a/buildkite/build_distribution.sh
+++ b/buildkite/build_distribution.sh
@@ -18,6 +18,8 @@ done
 
 echo "--- Building dub"
 cd dub
+# enable experimental build cache improvements https://github.com/dlang/dub/pull/1589
+sed -i 's|bool m_filterVersions = false;|bool m_filterVersions = true;|' source/dub/commandline.d
 DMD="../dmd/generated/linux/release/64/dmd" ./build.sh
 cd ..
 


### PR DESCRIPTION
- also see https://github.com/dlang/dub/pull/1589 and
  https://github.com/dlang/dub/pull/1624
- reduces test time for vibe-d's examples by ~50%