### PR TITLE
Retry nightly builds up to 3 times

### DIFF
--- a/buildkite/build_release_pipeline.yml
+++ b/buildkite/build_release_pipeline.yml
@@ -8,3 +8,6 @@ steps:
       - './buildkite/build_release.sh'
     agents:
       queue: release-builder
+    retry:
+      automatic:
+        limit: 2


### PR DESCRIPTION
Random failures also seem to happen here, the retry logic helped us quite a lot for the CI pipelines, so I think it could be benefitial here too.

See e.g. https://buildkite.com/dlang/build-release/builds/112#25005182-8ce8-46f7-a2c6-4ebd94b2c960