### PR TITLE
Revert "Disable Lubeck as it fails with dependency errors"

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -164,7 +164,7 @@ projects=(
     "DlangScience/scid"
     "ikod/dlang-requests"
     "kaleidicassociates/excel-d"
-    #"kaleidicassociates/lubeck" # https://github.com/kaleidicassociates/lubeck/issues/21
+    "kaleidicassociates/lubeck"
     "kyllingstad/zmqd"
     "lgvz/imageformats"
     "libmir/mir"


### PR DESCRIPTION
Reverts dlang/ci#376

So that it doesn't get lost, but lubeck has a bad track history now and I don't feel too inclined to have a project here which releases things with a broken CI on the project :/