### PR TITLE
ocean: Do not run d2conv

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -213,7 +213,6 @@ case "$REPO_FULL_NAME" in
 
     sociomantic-tsunami/ocean)
         git submodule update --init
-        make d2conv V=1
         make test V=1 DVER=2 F=production ALLOW_DEPRECATIONS=1
         ;;
 


### PR DESCRIPTION
Starting from v5.0.0, ocean dropped D1 support and is D2 only.

CC @mihails-strasuns @leandro-lucarella-sociomantic 