### PR TITLE
buildkite/build_project.sh: Remove ae.sys.net.test hack

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -229,8 +229,6 @@ case "$REPO_FULL_NAME" in
     CyberShadow/ae)
         # remove failing extended attribute test
         perl -0777 -pi -e "s/unittest[^{]*{[^{}]*xAttrs[^{}]*}//" sys/file.d
-        # remove network tests (they tend to timeout)
-        rm -f sys/net/test.d
         use_travis_test_script
         ;;
 


### PR DESCRIPTION
It is now handled in https://github.com/CyberShadow/ae/releases/tag/v0.0.2389.

Needed to unbreak ae in the BuildKite project tester.