### PR TITLE
Disable Mecca once again

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -142,7 +142,7 @@ projects=(
     #"d-gamedev-team/gfm" # 28s
     "gecko0307/dagon" # 25s
     "dlang-community/DCD" # 23s
-    "weka-io/mecca" # 22s
+    #"weka-io/mecca" # 22s
     "CyberShadow/ae" # 22s
     "jmdavis/dxml" # 22s
     "jacob-carlborg/dstep" # 18s


### PR DESCRIPTION
Reverts dlang/ci#395

Unfortunately the fix is not enough, apparently... And terrible to test.
Personally I'm fed up with fixing linking errors triggered by access to private symbols.