### PR TITLE
Revert "fix(clone_repos): only moves files of the repository from which the PR originated"

### DIFF
--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -19,10 +19,7 @@ if [ "${REPO_FULL_NAME:-none}" == "dlang/ci" ] ; then
 fi
 
 for dir in "${repositories[@]}" ; do
-    # repos cloned via the project tester can't be considered as existent
-    # except its the repository from which the PR was triggered
-    if [ "$origin_repo" == "$dir" ] &&
-        { [ "${REPO_FULL_NAME:-x}" == "x" ] || [ "$(basename "${REPO_FULL_NAME:-x}")" == "$origin_repo" ] ; }  ; then
+    if [ "$origin_repo" == "$dir" ] ; then
     # we have already cloned this repo, so let's use this data
         mkdir -p "$dir"
         find . -maxdepth 1 -mindepth 1 | while read -r f ; do


### PR DESCRIPTION
Reverts dlang/ci#352

Logs is as follows currently:

```
~> repositories=(dmd druntime phobos tools dub)
--
  | ~> '[' dlang/phobos == dlang/ci ']'
  | ~> for dir in '"${repositories[@]}"'
  | ~> '[' dmd == dmd ']'
  | ~> '[' dlang/phobos == x ']'
  | ~~> basename dlang/phobos
  | ~> '[' phobos == dmd ']'
  | ~> for dir in '"${repositories[@]}"'
...
  | ~> '[' dmd == dub ']'
  | ~> for dir in '"${repositories[@]}"'
  | ~> '[' '!' -d dmd ']'
  | ~> repo=https://github.com/dlang/dmd
  | ~~> /var/lib/buildkite-agent/builds/ci-agent-3336cc36-2797-42b6-ba5b-167d05f41167-1/dlang/dmd/build/buildkite/origin_target_branch.sh https://github.com/dlang/dmd
  | ~> branch=master
  | ~> echo 'target_branch: master'
  | target_branch: master
  | ~> git clone -b master --depth 1 https://github.com/dlang/dmd
```

e.g. https://buildkite.com/dlang/dmd/builds/8609#0b3e0ff1-a5dc-44cf-b706-f11177a968f6

I don't know why I added this check, so we will try removing it as this clearly prevents us from cloning the current PR for the respective repo.