### PR TITLE
Dub: Remove workaround, use Travis' script

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -186,8 +186,7 @@ case "$REPO_FULL_NAME" in
     dlang/dub)
         rm test/issue895-local-configuration.sh # FIXME
         rm test/issue884-init-defer-file-creation.sh # FIXME
-        sed -i '/^source.*activate/d' travis-ci.sh
-        DC=$DC ./travis-ci.sh
+        use_travis_test_script
         ;;
 
     dlang/tools)


### PR DESCRIPTION
Workaround unnecessary since https://github.com/dlang/dub/pull/1854
The exact call to `travis-ci.sh` blocks https://github.com/dlang/dub/pull/1853