### PR TITLE
Add a Dockerfile to build an agent

### DIFF
--- a/ansible/roles/test_deps/tasks/main.yml
+++ b/ansible/roles/test_deps/tasks/main.yml
@@ -47,7 +47,6 @@
   with_items:
     - https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=libebtree6_6.0.s7-rc5-xenial_amd64.deb
     - https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=libebtree6-dev_6.0.s7-rc5-xenial_amd64.deb
-    - https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=d1to2fix_0.10.0-alpha1-xenial_amd64.deb
 - name: disable mongodb journaling
   lineinfile: { dest: /etc/mongodb.conf, regexp: "^{{ item.key }} *=", line: "{{ item.key }} = {{ item.value }}" }
   with_dict:

--- a/buildkite/Dockerfile
+++ b/buildkite/Dockerfile
@@ -1,0 +1,13 @@
+FROM buildkite/agent:ubuntu
+
+ADD travis_get_script /usr/local/bin/get_travis_test_script
+RUN apt-get update && apt-get install -y build-essential cmake curl gdb git jq libblas-dev \
+    libbz2-dev libcairo-dev libcurl4-gnutls-dev libevent-dev libgcrypt20-dev libgpg-error-dev \
+    libgtk-3-0 liblapack-dev liblzo2-dev libopenblas-dev libreadline-dev libssl-dev libxml2-dev \
+    libxslt1-dev libzmq3-dev mongodb-server moreutils ninja-build \
+    pkg-config python-dev python-yaml python3-nose redis-server \
+    rsync unzip wget gnupg lsb-release apt-utils software-properties-common
+RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+RUN wget -O /root/libebtree.deb     https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=libebtree6_6.0.s7-rc5-xenial_amd64.deb
+RUN wget -O /root/libebtree-dev.deb https://bintray.com/sociomantic-tsunami/dlang/download_file?file_path=libebtree6-dev_6.0.s7-rc5-xenial_amd64.deb
+RUN dpkg -i /root/libebtree*.deb


### PR DESCRIPTION
```
This Dockerfile will allow administrator to quickly and easily deploy an agent.
The dependencies were extracted from ansible/roles/test_deps/tasks/main.yml.
A user can run the agent with:
$ docker build -t buildkite_agent buildkite
$ docker run -e BUILDKITE_AGENT_TOKEN='AGENT-TOKEN-HERE' buildkite_agent
Note that since this image is not intended to be distributed, the usual cleanup isn't done
(and no attempt was made to minimize the dependencies).
```

CC @wilzbach @PetarKirov : I'm running this on my server now so if any issue shows up we'll know soon enough. Might want to give it a few days to see if nothing fails (@wilzbach originally spotted failures because Ocean has a hard dependency on OpenSSL 1.0.0 and Arch only provides 1.1).