### PR TITLE
Disable kyllingstad/zmqd

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -168,7 +168,9 @@ projects=(
     "ikod/dlang-requests"
     "kaleidicassociates/excel-d"
     "kaleidicassociates/lubeck"
-    "kyllingstad/zmqd"
+    # Need a zmq version >= 4.3
+    # See https://github.com/kyllingstad/zmqd/blob/v1.2.0/CHANGELOG.md#changed
+    #"kyllingstad/zmqd"
     "lgvz/imageformats"
     "libmir/mir"
     "libmir/mir-core"


### PR DESCRIPTION
```
Since the new release, it requires a zmq >= 4.3 but the machines have 4.1.4.
```

A temporary measure to make Buildkite green again...
@wilzbach : I grepped for `zmq` but I only saw a reference to version 3 (?) in ansible. Any chance you could take a look at this ?
CC @kyllingstad (sorry, didn't foresee that one).