### PR TITLE
BuildKite: Don't use LDC *master* (but the latest tag instead)

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -233,9 +233,7 @@ case "$REPO_FULL_NAME" in
         ;;
 
     ldc-developers/ldc)
-        cd runtime && git clone --depth 5 https://github.com/ldc-developers/druntime
-        git clone --depth 5 https://github.com/ldc-developers/phobos
-        cd .. && git submodule update
+        git submodule update --init
         mkdir bootstrap && cd bootstrap
         cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DD_COMPILER="$DC" ..
         ninja -j2 ldmd2 druntime-ldc-debug phobos2-ldc-debug

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -33,10 +33,6 @@ case "$REPO_URL" in
         # Use master as Vibe.d covers a lot of the language features
         ref_to_use=master
         ;;
-    https://github.com/ldc-developers/ldc)
-        # ldc doesn't really do point releases, so master is easier to adapt if needed.
-        ref_to_use=master
-        ;;
     *)
         ;;
 esac


### PR DESCRIPTION
As a band-aid for the CI regression (due to LDC master now requiring LLVM 6+). Note that the next beta is scheduled for this evening, so someone should look into raising the installed LLVM version ASAP.