### PR TITLE
ansible: Bump LLVM to 8.0

### DIFF
--- a/ansible/roles/test_deps/tasks/main.yml
+++ b/ansible/roles/test_deps/tasks/main.yml
@@ -31,7 +31,7 @@
     - libxml2-dev
     - libxslt1-dev
     - libzmq3-dev
-    - llvm-3.9-dev # ldc
+    - llvm-8-dev # ldc
     - mongodb-server
     - moreutils # sponge et.al.
     - ninja-build # ldc


### PR DESCRIPTION
LLVM 6.0+ will be required from the next LDC release
(and is already required for LDC master).