### PR TITLE
Fix LDC regression with new Ansible image

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -231,11 +231,13 @@ case "$REPO_FULL_NAME" in
     ldc-developers/ldc)
         git submodule update --init
         mkdir bootstrap && cd bootstrap
+        export CC=clang-8
+        export CXX=clang++-8
         cmake .. \
           -GNinja \
           -DCMAKE_BUILD_TYPE=Debug \
           -DD_COMPILER="$DC" \
-          -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold # gold required for llvm-8 pkg
+          -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld # lld required for llvm-8 pkg
         ninja -j2 ldmd2 druntime-ldc-debug phobos2-ldc-debug
         cd ..
         mkdir build && cd build

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -231,11 +231,19 @@ case "$REPO_FULL_NAME" in
     ldc-developers/ldc)
         git submodule update --init
         mkdir bootstrap && cd bootstrap
-        cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DD_COMPILER="$DC" ..
+        cmake .. \
+          -GNinja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DD_COMPILER="$DC" \
+          -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold # gold required for llvm-8 pkg
         ninja -j2 ldmd2 druntime-ldc-debug phobos2-ldc-debug
         cd ..
         mkdir build && cd build
-        cmake -GNinja -DCMAKE_BUILD_TYPE=Debug -DD_COMPILER="$(pwd)/../bootstrap/bin/ldmd2" ..
+        cmake .. \
+          -GNinja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DD_COMPILER="$(pwd)/../bootstrap/bin/ldmd2" \
+          -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
         ninja -j2 ldc2 druntime-ldc phobos2-ldc
         ;;
 

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -235,7 +235,7 @@ case "$REPO_FULL_NAME" in
           -GNinja \
           -DCMAKE_BUILD_TYPE=Debug \
           -DD_COMPILER="$DC" \
-          -DCMAKE_CROSSCOMPILING=True # work around gen_gccbuiltins linker issue with llvm-8 pkg
+          -DCMAKE_SYSTEM_NAME=Linux # work around gen_gccbuiltins linker issue with llvm-8 pkg
         ninja -j2 ldmd2 druntime-ldc-debug phobos2-ldc-debug
         cd ..
         mkdir build && cd build
@@ -243,7 +243,7 @@ case "$REPO_FULL_NAME" in
           -GNinja \
           -DCMAKE_BUILD_TYPE=Debug \
           -DD_COMPILER="$(pwd)/../bootstrap/bin/ldmd2" \
-          -DCMAKE_CROSSCOMPILING=True # work around gen_gccbuiltins linker issue with llvm-8 pkg
+          -DCMAKE_SYSTEM_NAME=Linux # work around gen_gccbuiltins linker issue with llvm-8 pkg
         ninja -j2 ldc2 druntime-ldc phobos2-ldc
         ;;
 

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -231,13 +231,11 @@ case "$REPO_FULL_NAME" in
     ldc-developers/ldc)
         git submodule update --init
         mkdir bootstrap && cd bootstrap
-        export CC=clang
-        export CXX=clang++
         cmake .. \
           -GNinja \
           -DCMAKE_BUILD_TYPE=Debug \
           -DD_COMPILER="$DC" \
-          -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld # lld required for llvm-8 pkg
+          -DCMAKE_CROSSCOMPILING=True # work around gen_gccbuiltins linker issue with llvm-8 pkg
         ninja -j2 ldmd2 druntime-ldc-debug phobos2-ldc-debug
         cd ..
         mkdir build && cd build
@@ -245,7 +243,7 @@ case "$REPO_FULL_NAME" in
           -GNinja \
           -DCMAKE_BUILD_TYPE=Debug \
           -DD_COMPILER="$(pwd)/../bootstrap/bin/ldmd2" \
-          -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
+          -DCMAKE_CROSSCOMPILING=True # work around gen_gccbuiltins linker issue with llvm-8 pkg
         ninja -j2 ldc2 druntime-ldc phobos2-ldc
         ;;
 

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -231,8 +231,8 @@ case "$REPO_FULL_NAME" in
     ldc-developers/ldc)
         git submodule update --init
         mkdir bootstrap && cd bootstrap
-        export CC=clang-8
-        export CXX=clang++-8
+        export CC=clang
+        export CXX=clang++
         cmake .. \
           -GNinja \
           -DCMAKE_BUILD_TYPE=Debug \
@@ -245,7 +245,7 @@ case "$REPO_FULL_NAME" in
           -GNinja \
           -DCMAKE_BUILD_TYPE=Debug \
           -DD_COMPILER="$(pwd)/../bootstrap/bin/ldmd2" \
-          -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold
+          -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
         ninja -j2 ldc2 druntime-ldc phobos2-ldc
         ;;
 


### PR DESCRIPTION
The LLVM 8 libs seem unusable with the used bfd linker; switch to gold.