### PR TITLE
Add autodecode test to buildkite.

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -115,6 +115,7 @@ projects=(
     "ldc-developers/ldc" # 4m49s
     "vibe-d/vibe.d+base" # 4m31s
     "dlang/phobos" # 4m50s
+    "dlang/phobos+no-autodecode"
     "sociomantic-tsunami/ocean" # 4m49s
     "sociomantic-tsunami/swarm"
     "sociomantic-tsunami/turtle"
@@ -192,6 +193,7 @@ memory_req["libmir/mir-algorithm"]=high
 memory_req["sociomantic-tsunami/ocean"]=high
 memory_req["dlang-bots/dlang-bot"]=high
 memory_req["dlang/phobos"]=high
+memory_req["dlang/phobos+no-autodecode"]=high
 memory_req["dlang/dub"]=high
 memory_req["higgsjs/Higgs"]=high
 memory_req["d-language-server/dls"]=high

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -264,6 +264,12 @@ case "$REPO_FULL_NAME" in
             make -C druntime -j2 -f posix.mak
         fi
         cd "$(basename "${REPO_FULL_NAME}")"&& make -f posix.mak clean && make -f posix.mak -j2 buildkite-test
+        if [ "$REPO_FULL_NAME" == "dlang/phobos" ] ; then
+            # test autodecode items
+            export NO_AUTODECODE=1
+            echo "--- Running no-autodecode test"
+            make -f posix.mak clean && make -f posix.mak -j2 autodecode-test
+        fi
         rm -rf "$TMP"
         ;;
 


### PR DESCRIPTION
This is the next step in the process. In order to test autodecode PRs actually work and don't break later, we need to be able to test modules with no autodecode enabled as they are fixed.

See plan in https://github.com/dlang/phobos/pull/7586