### PR TITLE
Temporarily disable dlang-community/libdparse

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -144,7 +144,7 @@ projects=(
     "libmir/mir-algorithm" # 17s
     "dlang-community/D-YAML" # 15s
     "libmir/mir-random" # 13s
-    "dlang-community/libdparse" # 13s
+    #"dlang-community/libdparse" # 13s
     "aliak00/optional" # 12s
     "dlang-community/dfmt" # 11s
     "jacob-carlborg/dlp" # 11s


### PR DESCRIPTION
Release v0.16.0 requires an xml lib which broke the build.
See dlang-community/libdparse#431.