### PR TITLE
Temporarily use fixed version for libdparse ...

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -33,6 +33,12 @@ case "$REPO_URL" in
         # Use master as Vibe.d covers a lot of the language features
         ref_to_use=master
         ;;
+
+    https://github.com/dlang-community/libdparse)
+        # Freeze libdparse because of missing dependencies for the test suite
+        # See https://github.com/dlang-community/libdparse/issues/431
+        ref_to_use=v0.15.4
+        ;;
     *)
         ;;
 esac


### PR DESCRIPTION
... because it's test suite requires missing dependencies