### PR TITLE
Don't build removed dlang-requests configuration

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -232,7 +232,6 @@ case "$REPO_FULL_NAME" in
         # full test suite is currently disabled
         # see https://github.com/dlang/ci/pull/166
         dub build -c std
-        dub build -c vibed
         ;;
 
     libmir/mir-algorithm | \


### PR DESCRIPTION
The configuration 'vibed' was removed from dlang-requests in version
2.0.0, so attempting to build it will always fail.

---

This is currently blocking all new PRs to dmd/druntime/phobos.