### PR TITLE
Reduce a bit of the soul-crushing log spam created by buildkite

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -78,7 +78,7 @@ esac
 
 if [ "$ref_to_use" != "IS-ALREADY-CHECKED-OUT" ] ; then
     echo "--- Cloning ${REPO_URL} (tag: $ref_to_use)"
-    git clone -b "${ref_to_use}" --depth 1 "${REPO_URL}" "${REPO_DIR}"
+    git clone -b "${ref_to_use}" --depth 1 "${REPO_URL}" "${REPO_DIR}" --quiet
     cd "${REPO_DIR}"
 else
     # list the entire directory layout for debugging
@@ -278,6 +278,7 @@ case "$REPO_FULL_NAME" in
     dlang/druntime | \
     dlang/phobos)
         "$DIR"/clone_repositories.sh
+        echo "--- Launching test for $REPO_FULL_NAME"
         # To avoid running into "Path too long" issues, see e.g. https://github.com/dlang/ci/pull/287
         export TMP="/tmp/${BUILDKITE_AGENT_NAME}"
         export TEMP="$TMP"
@@ -296,6 +297,7 @@ case "$REPO_FULL_NAME" in
 
     dlang/phobos+no-autodecode)
         "$DIR"/clone_repositories.sh
+        echo "--- Launching test for $REPO_FULL_NAME"
         # To avoid running into "Path too long" issues, see e.g. https://github.com/dlang/ci/pull/287
         export TMP="/tmp/${BUILDKITE_AGENT_NAME}"
         export TEMP="$TMP"

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -46,6 +46,6 @@ for dir in "${repositories[@]}" ; do
         repo="https://github.com/dlang/$dir"
         branch=$("$DIR/origin_target_branch.sh" "$repo")
         echo "target_branch: $branch"
-        git clone -b "${branch:-master}" --depth 1 "$repo"
+        git clone -b "${branch:-master}" --depth 1 "$repo" --quiet
     fi
 done


### PR DESCRIPTION
First, the default git clone will output progress message every percent of the way, which is not useful for offline log inspection.

Second, buildkite uses the `---` prefix to group log output. However, that's not nested so calling the cloning script will group things the wrong way. So I added those `echo`s to distinguish cloning from building.

Related: isn't it excessive to output every single command run? I'd understand doing so temporarily for debugging (and even in that case I'd argue well-thought logging would be vastly better), but to leave it on by default seems much.