### PR TITLE
Buildkite: Bump LDC to master, to prepare for upcoming breaking opEquals order change

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -48,6 +48,10 @@ case "$REPO_URL" in
         # No tag includes https://github.com/vibe-d/vibe-core/commit/7833e425403c3804054b0bd16eacbf71fc7a28f4
         ref_to_use=master
         ;;
+    https://github.com/ldc-developers/ldc)
+        # No tag includes https://github.com/ldc-developers/ldc/commit/94748f842f2f663876490e72a6564f1c49b42c8b
+        ref_to_use=master
+        ;;
     *)
         ;;
 esac


### PR DESCRIPTION
This prepares Buildkite for https://github.com/dlang/dmd/pull/13593.