### PR TITLE
Allow to build both pre-merge and post-merge druntime

### DIFF
--- a/buildkite/build_distribution.sh
+++ b/buildkite/build_distribution.sh
@@ -11,11 +11,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 "$DIR/clone_repositories.sh"
 
 echo "--- Building dmd"
-dmd/compiler/src/bootstrap.sh
-echo "--- Building druntime"
-make -C dmd/druntime -f posix.mak --jobs=4
+dmd/src/bootstrap.sh
 
-for dir in phobos ; do
+for dir in druntime phobos ; do
     echo "--- Building $dir"
     make -C $dir -f posix.mak --jobs=4
 done
@@ -33,7 +31,7 @@ make -C tools -f posix.mak RELEASE=1 --jobs=4
 echo "--- Building distribution"
 mkdir -p distribution/{bin,imports,libs}
 cp --archive --link dmd/generated/linux/release/64/dmd dub/bin/dub tools/generated/linux/64/rdmd distribution/bin/
-cp --archive --link phobos/etc phobos/std dmd/druntime/import/* distribution/imports/
+cp --archive --link phobos/etc phobos/std druntime/import/* distribution/imports/
 cp --archive --link phobos/generated/linux/release/64/libphobos2.{a,so,so*[!o]} distribution/libs/
 echo '[Environment]' >> distribution/bin/dmd.conf
 echo 'DFLAGS=-I%@P%/../imports -L-L%@P%/../libs -L--export-dynamic -L--export-dynamic -fPIC' >> distribution/bin/dmd.conf

--- a/buildkite/clone_repositories.sh
+++ b/buildkite/clone_repositories.sh
@@ -11,7 +11,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 origin_repo="$(echo "$BUILDKITE_REPO" | sed "s/.*\/\([^\]*\)[.]git/\1/")"
 
 echo "--- Cloning all core repositories"
-repositories=(dmd phobos tools dub)
+repositories=(dmd druntime phobos tools dub)
 
 # For PRs to dlang/ci, clone itself too, s.t. the code below can be tested
 if [ "${REPO_FULL_NAME:-none}" == "dlang/ci" ] ; then


### PR DESCRIPTION
We need to keep pre-merge logic around for build_distribution,
which is not too much logic.