### PR TITLE
Fix Higgs build by re-adding Python2

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -233,11 +233,16 @@ cat << EOF
     ${DEFAULT_COMMAND_PROPS}
 EOF
 
-if [ "${memory_req["$project_name"]:-x}" != "x" ] ; then
+#if [ "${memory_req["$project_name"]:-x}" != "x" ] ; then
+#cat << EOF
+    #agents:
+      #- "memory=${memory_req["$project_name"]}"
+#EOF
+#fi
+
 cat << EOF
     agents:
-      - "memory=${memory_req["$project_name"]}"
+      - "testtag"
 EOF
-fi
 
 done

--- a/buildkite.sh
+++ b/buildkite.sh
@@ -233,16 +233,11 @@ cat << EOF
     ${DEFAULT_COMMAND_PROPS}
 EOF
 
-#if [ "${memory_req["$project_name"]:-x}" != "x" ] ; then
-#cat << EOF
-    #agents:
-      #- "memory=${memory_req["$project_name"]}"
-#EOF
-#fi
-
+if [ "${memory_req["$project_name"]:-x}" != "x" ] ; then
 cat << EOF
     agents:
-      - "testtag"
+      - "memory=${memory_req["$project_name"]}"
 EOF
+fi
 
 done

--- a/buildkite/Dockerfile
+++ b/buildkite/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
     libbz2-dev libcairo-dev libclang-dev libcurl4-gnutls-dev libevent-dev libgcrypt20-dev libgpg-error-dev \
     libgtk-3-0 liblapack-dev libldap2-dev liblzo2-dev libopenblas-dev libreadline-dev libssl-dev libxml2-dev \
     libxslt1-dev libzmq3-dev llvm-dev moreutils net-tools ninja-build \
-    pkg-config python3-dev python3-yaml python3-nose redis-server \
+    pkg-config python3-dev python3-yaml python3-nose python2-dev redis-server \
     rsync ruby ruby-dev ruby-dotenv sudo time unzip wget gnupg lsb-release \
     apt-utils software-properties-common
 

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -136,7 +136,7 @@ case "$REPO_FULL_NAME" in
         ;;
 
     higgsjs/Higgs)
-        make -C source test "DC=$DC"
+        make -C source test "DC=$DC" "PYTHON=python2"
         ;;
 
     vibe-d/vibe.d+base)


### PR DESCRIPTION
Higgs no longer compiles because we switched from python2 to python3 in Dockerfile. This is an attempt to fix it.