### PR TITLE
Add Funkwerk Mobility `serialized` and `mocked`.

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -195,6 +195,8 @@ projects=(
     "s-ludwig/std_data_json"
     "s-ludwig/taggedalgebraic"
     "snazzy-d/sdc"
+    "funkwerk-mobility/serialized" # 13s
+    "funkwerk-mobility/mocked" # 9s
     # Fails with some network issue
     #"MartinNowak/io"
 )


### PR DESCRIPTION
serialized also indirectly validates Funkwerk's boilerplate, dshould and prettyprint.
All of them are template heavy and well unittested, so it would be useful to have early warning if one of them was broken by a change.
Comment times are based on local runs.