### PR TITLE
Dockerfile: Add LLVM 15, the min version required for LDC v1.39

### DIFF
--- a/buildkite/Dockerfile
+++ b/buildkite/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     apt-get install -y build-essential clang cmake curl gdb git jq sqlite3 libblas-dev \
     libbz2-dev libcairo-dev libclang-dev libcurl4-gnutls-dev libevent-dev libgcrypt20-dev libgpg-error-dev \
     libgtk-3-0 liblapack-dev libldap2-dev liblzo2-dev libopenblas-dev libreadline-dev libssl-dev libxml2-dev \
-    libxslt1-dev libzmq3-dev llvm-dev moreutils net-tools ninja-build \
+    libxslt1-dev libzmq3-dev llvm-dev llvm-15-dev moreutils net-tools ninja-build \
     pkg-config python3-dev python3-yaml python3-nose redis-server \
     rsync ruby ruby-dev ruby-dotenv sudo time unzip wget gnupg lsb-release \
     apt-utils software-properties-common


### PR DESCRIPTION
The existing LLVM 14 (Ubuntu 22 default) is too old.