### PR TITLE
Replace gone symmetryinvestments/lubeck with kaleidicassociates/lubeck

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -176,7 +176,7 @@ projects=(
     "symmetryinvestments/concurrency"
     "symmetryinvestments/excel-d"
     "symmetryinvestments/ldapauth"
-    "symmetryinvestments/lubeck"
+    "kaleidicassociates/lubeck"
     "symmetryinvestments/xlsxreader"
     # Need a zmq version >= 4.3
     # See https://github.com/kyllingstad/zmqd/blob/v1.2.0/CHANGELOG.md#changed


### PR DESCRIPTION
AFAICT https://github.com/symmetryinvestments/lubeck is gone.
→ https://github.com/dlang/phobos/issues/10583