### PR TITLE
dlang/dub: Don't try to remove tests that aren't run

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -178,8 +178,6 @@ case "$REPO_FULL_NAME" in
         ;;
 
     dlang/dub)
-        rm test/issue895-local-configuration.sh # FIXME
-        rm test/issue884-init-defer-file-creation.sh # FIXME
         use_travis_test_script
         ;;
 


### PR DESCRIPTION
See https://github.com/dlang/dub/pull/3064#issuecomment-3140878190

1. It does nothing
2. It causes the run to fail when the tests are renamed/removed